### PR TITLE
Flat sky iau convention + config file

### DIFF
--- a/config_template.ini
+++ b/config_template.ini
@@ -1,0 +1,3 @@
+[general]
+
+iau_convention = False

--- a/enmap.py
+++ b/enmap.py
@@ -17,6 +17,15 @@ import numpy as np, scipy.ndimage, warnings, enlib.utils, enlib.wcs, enlib.slice
 #     simple to override individual properties.
 
 extent_model = ["subgrid"]
+try:
+        from ConfigParser import SafeConfigParser 
+        iniFile = "config.ini"
+        Config = SafeConfigParser()
+        Config.optionxform=str
+        Config.read(iniFile)
+        iau_convention = Config.getboolean("general","iau_convention")
+except:
+        iau_convention = False
 
 # PyFits uses row-major ordering, i.e. C ordering, while the fits file
 # itself uses column-major ordering. So an array which is (ncomp,ny,nx)
@@ -530,11 +539,17 @@ def queb_rotmat(lmap, inverse=False):
 	# tangential direction, not radial. This matches flipperpol too.
 	# This corresponds to the Healpix convention. To get IAU,
 	# flip the sign of a.
-	a    = 2*np.arctan2(-lmap[1], lmap[0])
-	c, s = np.cos(a), np.sin(a)
-	if inverse: s = -s
-	return samewcs(np.array([[c,-s],[s,c]]),lmap)
 
+        if iau_convention:
+                sgn = -1
+        else:
+                sgn = 1
+        a    = sgn*2*np.arctan2(-lmap[1], lmap[0])
+        c, s = np.cos(a), np.sin(a)
+        if inverse: s = -s
+        return samewcs(np.array([[c,-s],[s,c]]),lmap)
+
+	
 def rotate_pol(emap, angle, comps=[-2,-1]):
 	c, s = np.cos(2*angle), np.sin(2*angle)
 	res = emap.copy()

--- a/enmap.py
+++ b/enmap.py
@@ -540,10 +540,7 @@ def queb_rotmat(lmap, inverse=False):
 	# This corresponds to the Healpix convention. To get IAU,
 	# flip the sign of a.
 
-        if iau_convention:
-                sgn = -1
-        else:
-                sgn = 1
+        sgn = -1 if iau_convention else 1
         a    = sgn*2*np.arctan2(-lmap[1], lmap[0])
         c, s = np.cos(a), np.sin(a)
         if inverse: s = -s


### PR DESCRIPTION
Hi Sigurd,

This is the first in a series of pull requests. This time I'm doing it systematically keeping unrelated PRs separate.

This one reads a flag for "iau_convention" from "config.ini" if it can find it. If it can't, it defaults to the standard "iau_convention=False". 

The PR supplies a template "config_template.ini" which can be extended for other global parameters. (It can be copied to "config.ini" by the user, but "config.ini" is not meant to be in the git tree)

Best,
Mat 