### PR TITLE
Show warning if curvedsky cannot be imported through lensing

### DIFF
--- a/lensing.py
+++ b/lensing.py
@@ -1,5 +1,11 @@
 import numpy as np
-from enlib import enmap, utils, powspec, sharp, curvedsky, interpol
+from enlib import enmap, utils, powspec, interpol
+try:
+        import curvedsky
+except:
+        import traceback, logging
+        traceback.print_exc()
+        logging.warn("Enlib: Couldn't load curvedsky. You probably need to install libsharp. Some functions won't work.")
 
 ####### Flat sky lensing #######
 


### PR DESCRIPTION
Libsharp is not necessarily easy to install for everyone (and its installation is not documented here). This shouldn't prevent people from using the excellent flat-sky lensing tools in `lensing.py`. This PR will show a warning if `lensing.py` cannot import `curvedsky.py`.