### PR TITLE
2d power support for rand_map

### DIFF
--- a/enmap.py
+++ b/enmap.py
@@ -335,14 +335,23 @@ def _arghelper(map, func, unit):
 	if unit == "coord": res = pix2sky(map.shape, map.wcs, res.T).T
 	return res
 
-def rand_map(shape, wcs, cov, scalar=False, seed=None):
+
+def rand_map(shape, wcs, cov, scalar=False, seed=None,pixel_units=False):
 	"""Generate a standard flat-sky pixel-space CMB map in TQU convention based on
-	the provided power spectrum."""
+	the provided power spectrum.
+
+        If cov.ndim is 4, 2D power is assumed else 1D power is assumed.
+
+        If pixel_units is True, the 2D power spectra is assumed to be in pixel units,
+        not in steradians.
+        """
 	if seed is not None: np.random.seed(seed)
+        kmap = rand_gauss_iso_harm(shape, wcs, cov, pixel_units)
 	if scalar:
-		return ifft(rand_gauss_iso_harm(shape, wcs, cov)).real
+		return ifft(kmap).real
 	else:
-		return harm2map(rand_gauss_iso_harm(shape, wcs, cov))
+		return harm2map(kmap)
+
 
 def rand_gauss(shape, wcs, dtype=None):
 	"""Generate a map with random gaussian noise in pixel space."""
@@ -355,11 +364,28 @@ def rand_gauss_harm(shape, wcs):
 	passed, the result will be an enmap."""
 	return ndmap(np.random.standard_normal(shape)+1j*np.random.standard_normal(shape),wcs)
 
-def rand_gauss_iso_harm(shape, wcs, cov):
-	"""Generates an isotropic random map with component covariance
-	cov in harmonic space, where cov is a (comp,comp,l) array."""
-	data = map_mul(spec2flat(shape, wcs, cov, 0.5, mode="constant"), rand_gauss_harm(shape, wcs))
+
+def rand_gauss_iso_harm(shape, wcs, cov, pixel_units=False):
+	"""Generates a random map with component covariance
+	cov in harmonic space, where cov is a (comp,comp,l) array or a 
+        (comp,comp,Ny,Nx) array. Despite the name, the map doesn't need
+        to be isotropic since 2D power spectra are allowed.
+
+        If cov.ndim is 4, cov is assumed to be an array of 2D power spectra.
+        else cov is assumed to be an array of 1D power spectra.
+        If pixel_units is True, the 2D power spectra is assumed to be in pixel units,
+        not in steradians. 
+        """
+
+        if cov.ndim==4:
+                if not(pixel_units): cov = cov * np.prod(shape[-2:])/area(shape,wcs )
+                covsqrt = multi_pow(cov, 0.5)
+        else:
+                covsqrt = spec2flat(shape, wcs, cov, 0.5, mode="constant")
+
+	data = map_mul(covsqrt, rand_gauss_harm(shape, wcs))
 	return ndmap(data, wcs)
+
 
 def extent(shape, wcs, method="default", nsub=None):
 	if method == "default": method = extent_model[-1]


### PR DESCRIPTION
This modifies `rand_map` and `rand_gauss_iso_harm` to accept arrays of 2D power instead of just 1d power. Detects ndim of input `cov` to decide.