### PR TITLE
Fixed bug in rand_map when checking length of shape.

### DIFF
--- a/curvedsky.py
+++ b/curvedsky.py
@@ -13,7 +13,7 @@ def rand_map(shape, wcs, ps, lmax=None, dtype=np.float64, seed=None, oversample=
 	# Ensure everything has the right dimensions and restrict to relevant dimensions
 	ps = utils.atleast_3d(ps)
 	if not ps.shape[0] == ps.shape[1]: raise ShapeError("ps must be [ncomp,ncomp,nl] or [nl]")
-	if not len(shape) == 2 or len(shape) == 3: raise ShapeError("shape must be (ncomp,ny,nx) or (ny,nx)")
+	if not (len(shape) == 2 or len(shape) == 3): raise ShapeError("shape must be (ncomp,ny,nx) or (ny,nx)")
 	ncomp = 1 if len(shape) == 2 else shape[-3]
 	ps = ps[:ncomp,:ncomp]
 


### PR DESCRIPTION
In `curvedsky.rand_map()`, the `len(shape)` check fails with previously working and tested script.
The current implementation fails due to logic ordering, which worked before with `assert()`. This small pull request should fix it.