### PR TITLE
MPI disable option

### DIFF
--- a/mpi.py
+++ b/mpi.py
@@ -1,5 +1,5 @@
 """Utilities for making mpi use safer and easier."""
-import sys
+import sys,os
 
 try:
 	disable_mpi_env = os.environ['DISABLE_MPI']

--- a/mpi.py
+++ b/mpi.py
@@ -1,6 +1,14 @@
 """Utilities for making mpi use safer and easier."""
 import sys
-from mpi4py.MPI import *
+
+try:
+	disable_mpi_env = os.environ['DISABLE_MPI']
+	disable_mpi = True if disable_mpi_env.lower().strip() == "true" else False
+except:
+	disable_mpi = False
+
+if not(disable_mpi):
+	from mpi4py.MPI import *
 # Uncaught exceptions don't cause mpi to abort. This can lead to thousands of
 # wasted CPU hours
 def cleanup(type, value, traceback):


### PR DESCRIPTION
On some systems (e.g NERSC login node where one might want to do some quick debugging), enlib's attempts to load MPI result in a fatal error that cannot be caught:
```
In [1]: from enlib import mpi
[Mon Apr  2 14:30:13 2018] [unknown] Fatal error in PMPI_Init_thread: Other MPI error, error stack:
MPIR_Init_thread(537): 
MPID_Init(247).......: channel initialization failed
MPID_Init(636).......:  PMI2 init failed: 1 
Aborted (core dumped)
```

This PR recognizes the environment variable DISABLE_MPI , and simply avoids loading mpi4py if that environment variable is set to true.
