### PR TITLE
lensing.rand_map: make separate lensing and CMB sim maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Curved-sky maps
 * Primary modules: `curvedsky`, `lensing`
 * Internal dependencies: `sharp` + [flat-sky maps]
 * External dependencies: [`libsharp`](http://sourceforge.net/projects/libsharp/), [`cython`](http://cython.org)
-* To build: `make sharp`
+* To build: `make sharp`, `make interpol` 
 
 Mapmaking
 ---------

--- a/lensing.py
+++ b/lensing.py
@@ -57,9 +57,9 @@ def displace_map(imap, pix, order=3, mode="spline", border="cyclic", trans=False
         if not deriv: omap = imap.copy()
         else:         omap = enmap.empty((2,)+imap.shape, imap.wcs, imap.dtype)
         if not trans:
-        interpol.map_coordinates(imap, pix, omap, order=order, mode=mode, border=border, trans=trans, deriv=deriv)
+                interpol.map_coordinates(imap, pix, omap, order=order, mode=mode, border=border, trans=trans, deriv=deriv)
         else:
-        interpol.map_coordinates(omap, pix, imap, order=order, mode=mode, border=border, trans=trans, deriv=deriv)
+                interpol.map_coordinates(omap, pix, imap, order=order, mode=mode, border=border, trans=trans, deriv=deriv)
         return omap
 
 # Compatibility function. Not quite equivalent lens_map above due to taking phi rather than

--- a/lensing.py
+++ b/lensing.py
@@ -54,13 +54,13 @@ def displace_map(imap, pix, order=3, mode="spline", border="cyclic", trans=False
         """Displace map m[{pre},ny,nx] by pix[2,ny,nx], where pix indicates the location
         in the input map each output pixel should get its value from (float). The output
         is [{pre},ny,nx]."""
-        if not deriv: omap = imap.copy()
-        else:         omap = enmap.empty((2,)+imap.shape, imap.wcs, imap.dtype)
-        if not trans:
-                interpol.map_coordinates(imap, pix, omap, order=order, mode=mode, border=border, trans=trans, deriv=deriv)
-        else:
-                interpol.map_coordinates(omap, pix, imap, order=order, mode=mode, border=border, trans=trans, deriv=deriv)
-        return omap
+	if not deriv: omap = imap.copy()
+	else:         omap = enmap.empty((2,)+imap.shape, imap.wcs, imap.dtype)
+	if not trans:
+		interpol.map_coordinates(imap, pix, omap, order=order, mode=mode, border=border, trans=trans, deriv=deriv)
+	else:
+		interpol.map_coordinates(omap, pix, imap, order=order, mode=mode, border=border, trans=trans, deriv=deriv)
+	return omap
 
 # Compatibility function. Not quite equivalent lens_map above due to taking phi rather than
 # its gradient as an argument.

--- a/lensing.py
+++ b/lensing.py
@@ -51,7 +51,7 @@ def delens_grad(grad_phi, nstep=3, order=3, mode="spline", border="cyclic"):
 	return alpha
 
 def displace_map(imap, pix, order=3, mode="spline", border="cyclic", trans=False, deriv=False):
-        """Displace map m[{pre},ny,nx] by pix[2,ny,nx], where pix indicates the location
+	"""Displace map m[{pre},ny,nx] by pix[2,ny,nx], where pix indicates the location
         in the input map each output pixel should get its value from (float). The output
         is [{pre},ny,nx]."""
 	if not deriv: omap = imap.copy()

--- a/lensing.py
+++ b/lensing.py
@@ -52,8 +52,8 @@ def delens_grad(grad_phi, nstep=3, order=3, mode="spline", border="cyclic"):
 
 def displace_map(imap, pix, order=3, mode="spline", border="cyclic", trans=False, deriv=False):
 	"""Displace map m[{pre},ny,nx] by pix[2,ny,nx], where pix indicates the location
-        in the input map each output pixel should get its value from (float). The output
-        is [{pre},ny,nx]."""
+	in the input map each output pixel should get its value from (float). The output
+	is [{pre},ny,nx]."""
 	if not deriv: omap = imap.copy()
 	else:         omap = enmap.empty((2,)+imap.shape, imap.wcs, imap.dtype)
 	if not trans:

--- a/lensing.py
+++ b/lensing.py
@@ -81,20 +81,20 @@ def rand_map(shape, wcs, ps_lensinput, lmax=None, maplmax=None, dtype=np.float64
 	oshape  = shape[-3:]
 	if len(oshape) == 2: shape = (1,)+tuple(shape)
 
-        #van Engelen added this:
+	#van Engelen added this:
 
 	# First draw a random lensing field, and use it to compute the undeflected positions
-        if not separate_phi_from_cmb:
-                #AVE - this was the default option.
-                if verbose: print("Generating alms")
-                alm, ainfo = curvedsky.rand_alm(ps_lensinput, lmax=lmax, seed=seed, dtype=ctype, return_ainfo=True)
-                phi_alm, cmb_alm = alm[0], alm[1:1+shape[-3]]
-	        del alm
+	if not separate_phi_from_cmb:
 
+		#AVE - this was the default option.
+		if verbose: print("Generating alms")
+		alm, ainfo = curvedsky.rand_alm(ps_lensinput, lmax=lmax, seed=seed, dtype=ctype, return_ainfo=True)
+		phi_alm, cmb_alm = alm[0], alm[1:1+shape[-3]]
+		del alm
         else:
-                if verbose: print("Generating alms, separating phi from cmb")
-                phi_alm, phi_ainfo = curvedsky.rand_alm(ps_lensinput[0, 0, :], lmax=lmax, seed=phi_seed, dtype=ctype, return_ainfo=True)
-                cmb_alm, cmb_ainfo = curvedsky.rand_alm(ps_lensinput[1:, 1:, :], lmax=lmax, seed=seed, dtype=ctype, return_ainfo=True)
+		if verbose: print("Generating alms, separating phi from cmb")
+		phi_alm, phi_ainfo = curvedsky.rand_alm(ps_lensinput[0, 0, :], lmax=lmax, seed=phi_seed, dtype=ctype, return_ainfo=True)
+		cmb_alm, cmb_ainfo = curvedsky.rand_alm(ps_lensinput[1:, 1:, :], lmax=lmax, seed=seed, dtype=ctype, return_ainfo=True)
 	# Truncate alm if we want a smoother map. In taylens, it was necessary to truncate
 	# to a lower lmax for the map than for phi, to avoid aliasing. The appropriate lmax
 	# for the cmb was the one that fits the resolution. FIXME: Can't slice alm this way.

--- a/lensing.py
+++ b/lensing.py
@@ -1,5 +1,5 @@
 import numpy as np
-from enlib import enmap, utils, powspec, interpol
+from . import enmap, utils, powspec, interpol
 
 ####### Flat sky lensing #######
 

--- a/lensing.py
+++ b/lensing.py
@@ -51,31 +51,16 @@ def delens_grad(grad_phi, nstep=3, order=3, mode="spline", border="cyclic"):
 	return alpha
 
 def displace_map(imap, pix, order=3, mode="spline", border="cyclic", trans=False, deriv=False):
-	"""Displace map m[{pre},ny,nx] by pix[2,ny,nx], where pix indicates the location
-	in the input map each output pixel should get its value from (float). The output
-	is [{pre},ny,nx]."""
-	iwork = np.empty(imap.shape[-2:]+imap.shape[:-2],imap.dtype)
-	if not deriv:
-		out = imap.copy()
-	else:
-		out = enmap.empty((2,)+imap.shape, imap.wcs, imap.dtype)
-	# Why do we have to manually allocate outputs and juggle whcih is copied over here?
-	# Because it is in general not possible to infer from odata what shape idata should have.
-	# So the map_coordinates can't allocate the output array automatically in the transposed
-	# case. But in this function we know that they will have the same shape, so we can.
-	if not trans:
-		iwork[:] = utils.moveaxes(imap, (-2,-1), (0,1))
-		owork = interpol.map_coordinates(iwork, pix, order=order, mode=mode, border=border, trans=trans, deriv=deriv)
-		out[:] = utils.moveaxes(owork, (0,1), (-2,-1))
-	else:
-		if not deriv:
-			owork = iwork.copy()
-		else:
-			owork = np.empty(imap.shape[-2:]+(2,)+imap.shape[:-2],imap.dtype)
-		owork[:] = utils.moveaxes(imap, (-2,-1), (0,1))
-		interpol.map_coordinates(iwork, pix, owork, order=order, mode=mode, border=border, trans=trans, deriv=deriv)
-		out[:] = utils.moveaxes(iwork, (0,1), (-2,-1))
-	return out
+        """Displace map m[{pre},ny,nx] by pix[2,ny,nx], where pix indicates the location
+        in the input map each output pixel should get its value from (float). The output
+        is [{pre},ny,nx]."""
+        if not deriv: omap = imap.copy()
+        else:         omap = enmap.empty((2,)+imap.shape, imap.wcs, imap.dtype)
+        if not trans:
+        interpol.map_coordinates(imap, pix, omap, order=order, mode=mode, border=border, trans=trans, deriv=deriv)
+        else:
+        interpol.map_coordinates(omap, pix, imap, order=order, mode=mode, border=border, trans=trans, deriv=deriv)
+        return omap
 
 # Compatibility function. Not quite equivalent lens_map above due to taking phi rather than
 # its gradient as an argument.

--- a/sharp/Makefile
+++ b/sharp/Makefile
@@ -5,7 +5,7 @@ sharp.so: sharp.c csharp.h
 ifeq ($(CC),icc)
 	LDSHARED="icc -shared" CC=icc $(PYTHON) setup.py build_ext --inplace
 else
-        $(CC) -o foo $(objects) $(normal_libs)
+	$(CC) -o foo $(objects) $(normal_libs)
 endif
 
 

--- a/sharp/Makefile
+++ b/sharp/Makefile
@@ -1,7 +1,16 @@
 include ../compile_opts/$(ENLIB_COMP).mk
 all: sharp.so tidy
 sharp.so: sharp.c csharp.h
-	$(PYTHON) setup.py build_ext --inplace
+#Alex added this statement -- if you have compiled sharp with icc it seems you need to have this
+ifeq ($(CC),icc)
+	LDSHARED="icc -shared" CC=icc $(PYTHON) setup.py build_ext --inplace
+else
+        $(CC) -o foo $(objects) $(normal_libs)
+endif
+
+
+# $(PYTHON) setup.py build_ext --inplace
+
 sharp.c: sharp.pyx csharp.pxd
 	cython sharp.pyx
 	perl -pi -e 's/typedef npy_float64 _Complex/typedef double _Complex/;s/typedef npy_float32 _Complex/typedef float _Complex/' sharp.c

--- a/sharp/Makefile
+++ b/sharp/Makefile
@@ -4,8 +4,7 @@ sharp.so: sharp.c csharp.h
 	$(PYTHON) setup.py build_ext --inplace
 sharp.c: sharp.pyx csharp.pxd
 	cython sharp.pyx
-	sed 's/typedef npy_float64 _Complex/typedef double _Complex/;s/typedef npy_float32 _Complex/typedef float _Complex/' sharp.c > tmp.c
-	mv tmp.c sharp.c
+	perl -pi -e 's/typedef npy_float64 _Complex/typedef double _Complex/;s/typedef npy_float32 _Complex/typedef float _Complex/' sharp.c
 clean:
 	rm -rf *.so *.pyc sharp.c
 tidy:

--- a/sharp/Makefile
+++ b/sharp/Makefile
@@ -1,16 +1,7 @@
 include ../compile_opts/$(ENLIB_COMP).mk
 all: sharp.so tidy
 sharp.so: sharp.c csharp.h
-#Alex added this statement -- if you have compiled sharp with icc it seems you need to have this
-ifeq ($(CC),icc)
-	LDSHARED="icc -shared" CC=icc $(PYTHON) setup.py build_ext --inplace
-else
-	$(CC) -o foo $(objects) $(normal_libs)
-endif
-
-
-# $(PYTHON) setup.py build_ext --inplace
-
+	$(PYTHON) setup.py build_ext --inplace
 sharp.c: sharp.pyx csharp.pxd
 	cython sharp.pyx
 	perl -pi -e 's/typedef npy_float64 _Complex/typedef double _Complex/;s/typedef npy_float32 _Complex/typedef float _Complex/' sharp.c

--- a/sharp/Makefile
+++ b/sharp/Makefile
@@ -1,7 +1,8 @@
 include ../compile_opts/$(ENLIB_COMP).mk
 all: sharp.so tidy
 sharp.so: sharp.c csharp.h
-	$(PYTHON) setup.py build_ext --inplace
+	LDSHARED="icc -shared" CC=icc $(PYTHON) setup.py build_ext --inplace
+	# $(PYTHON) setup.py build_ext --inplace
 sharp.c: sharp.pyx csharp.pxd
 	cython sharp.pyx
 	perl -pi -e 's/typedef npy_float64 _Complex/typedef double _Complex/;s/typedef npy_float32 _Complex/typedef float _Complex/' sharp.c

--- a/sharp/Makefile
+++ b/sharp/Makefile
@@ -1,11 +1,11 @@
 include ../compile_opts/$(ENLIB_COMP).mk
 all: sharp.so tidy
 sharp.so: sharp.c csharp.h
-	LDSHARED="icc -shared" CC=icc $(PYTHON) setup.py build_ext --inplace
-	# $(PYTHON) setup.py build_ext --inplace
+	$(PYTHON) setup.py build_ext --inplace
 sharp.c: sharp.pyx csharp.pxd
 	cython sharp.pyx
-	perl -pi -e 's/typedef npy_float64 _Complex/typedef double _Complex/;s/typedef npy_float32 _Complex/typedef float _Complex/' sharp.c
+	sed 's/typedef npy_float64 _Complex/typedef double _Complex/;s/typedef npy_float32 _Complex/typedef float _Complex/' sharp.c > tmp.c
+	mv tmp.c sharp.c
 clean:
 	rm -rf *.so *.pyc sharp.c
 tidy:


### PR DESCRIPTION
For some terms in lensing biases we need to have multiple CMB maps lensed by the same lensing potential map. I thus added some options to lensing.rand_map to make this possible.

Note that this means there will be no T-phi correlations or E-phi correlations, due to the integrated Sachs-Wolfe effect or reionization respectively.