### PR TITLE
Import fixes

### DIFF
--- a/array_ops/__init__.py
+++ b/array_ops/__init__.py
@@ -1,1 +1,1 @@
-from interface import *
+from .interface import *

--- a/array_ops/interface.py
+++ b/array_ops/interface.py
@@ -1,6 +1,6 @@
 import numpy as np
 from .. import utils
-import fortran_32, fortran_64, fortran_c64, fortran_c128
+from . import fortran_32, fortran_64, fortran_c64, fortran_c128
 
 def get_core(dtype):
 	if   dtype == np.float32:    return fortran_32.array_ops


### PR DESCRIPTION
array_ops import structure doesn't work with Python 3. This PR fixes that.